### PR TITLE
Adding WikiForum to repo

### DIFF
--- a/roles/mediawiki/vars/main.yml
+++ b/roles/mediawiki/vars/main.yml
@@ -611,6 +611,11 @@ extensions:
     version: 'REL1_24'
     }
   - { 
+    repo: 'https://github.com/wikimedia/mediawiki-extensions-WikiForum.git',
+    dest: 'extensions/WikiForum', 
+    version: 'master'
+    }
+  - { 
     repo: 'https://github.com/mediawiki4intranet/Wikilog.git',
     dest: 'extensions/Wikilog', 
     version: 'master'


### PR DESCRIPTION
used master branch due to it having continuous updates for stability