### PR TITLE
remove DismissableSiteNotice

### DIFF
--- a/roles/mediawiki/files/localsettings/GlobalExtensions.php
+++ b/roles/mediawiki/files/localsettings/GlobalExtensions.php
@@ -16,7 +16,6 @@ require_once( "$IP/extensions/CheckUser/CheckUser.php" );
 require_once( "$IP/extensions/Cite/Cite.php" );
 require_once( "$IP/extensions/Cite/SpecialCite.php" );
 require_once( "$IP/extensions/CollapsibleVector/CollapsibleVector.php" );
-require_once( "$IP/extensions/DismissableSiteNotice/DismissableSiteNotice.php" );
 require_once( "$IP/extensions/intersection/DynamicPageList.php" );
 require_once( "$IP/extensions/EventLogging/EventLogging.php" );
 require_once( "$IP/extensions/Gadgets/Gadgets.php" );


### PR DESCRIPTION
I moved it to local extensions (enabled by default) so it can be disabled on certain wikis.

Make sure to do #566 and #567 before this one.