### PR TITLE
Create Timezone for librewiki

### DIFF
--- a/roles/mediawiki/files/localsettings/LocalSettings.php.j2
+++ b/roles/mediawiki/files/localsettings/LocalSettings.php.j2
@@ -1696,6 +1696,7 @@ $wgConf->settings = array(
 		'default' => 'Europe/London',
 		'donjonwiki' => 'Europe/Paris',
 		'ironperfectionwiki' => 'America/Detroit',
+		'librewiki' => 'Asia/Seoul',
 		'lovelivesiftwwiki' => 'Asia/Taipei',
 		'nsswiki' => 'Asia/Seoul',
 		'quantixhl2rpwiki' => 'America/Detroit',


### PR DESCRIPTION
Defaults to Asia/Seoul.

I'm the creator of librewiki, therefore no meta RF request or such.