### PR TITLE
Deleting tintlewiki logo (wiki deleted)

### DIFF
--- a/roles/mediawiki/files/localsettings/LocalSettings.php.j2
+++ b/roles/mediawiki/files/localsettings/LocalSettings.php.j2
@@ -1910,7 +1910,6 @@ $wgConf->settings = array(
 		'szkwiki' => "//$wmgUploadHostname/szk.orain.org/images/c/c1/SzKLogo.png",
 		'spiralwiki' => '//upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Spiral_project_logo.svg/135px-Spiral_project_logo.svg.png',
 		'testwiki' => "//$wmgUploadHostname/test.orain.org/images/8/8d/Twlogo.png",
-		'tintlewiki' => "//$wmgUploadHostname/meta.orain.org/images/d/de/Logo_TintleWiki.png",
 		'ucdgsawiki' => "//$wmgUploadHostname/ucdgsa.orain.org/images/c/c9/Logo.png",	
 		'wh40kwiki' => "//$wmgUploadHostname/wh40k.orain.org/images/0/09/Encyclopedium.png",
 		'wikiconstituciowiki' => '//upload.wikimedia.org/wikipedia/commons/thumb/c/ce/Flag_of_Catalonia.svg/135px-Flag_of_Catalonia.svg.png',


### PR DESCRIPTION
Deleting logo as the wiki is deleted/archived.