### PR TITLE
changing LocalisationUpdate branch to master

### DIFF
--- a/roles/mediawiki/vars/main.yml
+++ b/roles/mediawiki/vars/main.yml
@@ -268,7 +268,7 @@ extensions:
   - { 
     repo: 'https://github.com/wikimedia/mediawiki-extensions-LocalisationUpdate.git',
     dest: 'extensions/LocalisationUpdate', 
-    version: 'REL1_24'
+    version: 'master'
     }
   - { 
     repo: 'https://github.com/wikimedia/mediawiki-extensions-Lockdown.git',


### PR DESCRIPTION
noticed some commits to Wikimedia repo that should have fixed the LC degeneration issues noted in this issue:

https://github.com/Orain/ansible-playbook/issues/650

Extension is database and extension agnostic (it only affects the LC cache building for extensions), so this change should not harm anything, at worst messages may break (they do so already at regular intervals that require manual intervention to fix daily) and this change will be instantly reverted and cache will be rebuilt.