### PR TITLE
Revert "to fix founder rights"

### DIFF
--- a/roles/mariadb/templates/debian.cnf.j2
+++ b/roles/mariadb/templates/debian.cnf.j2
@@ -10,5 +10,3 @@ user     = debian-sys-maint
 password = {{deb_db_password}}
 socket   = /var/run/mysqld/mysqld.sock
 basedir  = /usr
-transaction-isolation          = READ-COMMITTED
-binlog_format                  = ROW


### PR DESCRIPTION
After talking to John he told me that Debian config is different than what we have at Miraheze, so this change does not apply for Orain, it has also been confirmed that founder rights don't work.
@addshore @NDKilla 